### PR TITLE
Tree-statistics tooling: build heuristic via TreeSearch (consistency with fitter)

### DIFF
--- a/model_fitting/calculate_tree_statistics.py
+++ b/model_fitting/calculate_tree_statistics.py
@@ -1,0 +1,98 @@
+"""Tree statistics (planning depth + branching factor) for a fitted model.
+
+FIX (2026-07): build the heuristic the SAME way the fitter does — via
+tree_search.TreeSearch.set_params (the modular create(7,False)+add_feature_group
+path) — instead of the legacy bads_parameters_to_model_parameters -> create(58,True)
+path, which produced a *different* heuristic than what was fit and so gave
+inconsistent depth/branching numbers.
+
+Params file = one comma-separated line of the fitted BADS parameters in the model's
+parameter order (pruning_threshold, stopping_prob, feature_drop, lapse_rate, opp_scale,
+center_weight, then feature-group weights). This is exactly what the fit/adapter writes.
+"""
+import argparse
+import csv
+
+import numpy as np
+from tqdm import tqdm
+
+from parsers import parse_participant_file
+from ninarow_utilities import search_from_position
+from tree_search import TreeSearch
+
+
+def sample_planning_depth(heuristic, positions, num_samples, disable_tqdm=True):
+    total = 0
+    for position in tqdm(positions, disable=disable_tqdm):
+        for _ in range(num_samples):
+            total += search_from_position(position, heuristic).get_depth_of_pv()
+    return float(total) / (len(positions) * num_samples)
+
+
+def sample_average_branching_factor(heuristic, positions, num_samples, disable_tqdm=True):
+    total = 0.0
+    for position in tqdm(positions, disable=disable_tqdm):
+        for _ in range(num_samples):
+            total += search_from_position(position, heuristic).get_average_branching_factor()
+    return float(total) / (len(positions) * num_samples)
+
+
+def calculate_tree_statistics_from_file(path, heuristic, num_samples=10, branching=False):
+    moves = parse_participant_file(path)
+    positions = [move.board for move in moves]
+    depth = sample_planning_depth(heuristic, positions, num_samples, False)
+    if branching:
+        return depth, sample_average_branching_factor(heuristic, positions, num_samples, False)
+    return depth
+
+
+def heuristic_from_params_file(params_path):
+    """Build the fitted heuristic via TreeSearch (same construction as fit_one_start),
+    so tree statistics reflect the model that was actually fit."""
+    with open(params_path) as f:
+        for line in f:
+            if line.startswith("#") or not line.strip():
+                continue
+            params = np.array([float(x) for x in line.strip().split(",")], dtype=np.float32)
+            break
+    ts = TreeSearch(verbose=False)
+    if len(params) != len(ts.parameter_list):
+        raise ValueError(
+            f"{params_path}: got {len(params)} params, model expects {len(ts.parameter_list)} "
+            f"({[p['name'] for p in ts.parameter_list]})")
+    ts.set_params(params)
+    return ts.heuristic
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-f", "--participant_file", required=True, type=str,
+                        help="File containing the positions to analyze.")
+    parser.add_argument("-p", "--params", type=str,
+                        help="Fitted BADS parameters file (comma-separated, model order).")
+    parser.add_argument("-o", "--output", type=str,
+                        help="CSV file to write the statistic(s) to. Optional.")
+    parser.add_argument("-n", "--num_samples", type=int, default=10,
+                        help="Samples per position (averages over search stochasticity).")
+    parser.add_argument("-b", "--branching_factor", type=bool, default=False,
+                        help="Also compute branching factor.")
+    args = parser.parse_args()
+
+    if args.params:
+        heuristic = heuristic_from_params_file(args.params)
+    else:
+        import fourbynine
+        heuristic = fourbynine.fourbynine_heuristic.create()
+
+    stats = calculate_tree_statistics_from_file(
+        args.participant_file, heuristic, num_samples=args.num_samples,
+        branching=bool(args.branching_factor))
+    stats = list(stats) if isinstance(stats, tuple) else [stats]
+    print(stats)
+    if args.output:
+        with open(args.output, "w") as f:
+            csv.writer(f).writerow(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/model_fitting/ninarow_utilities.py
+++ b/model_fitting/ninarow_utilities.py
@@ -1,0 +1,107 @@
+import numpy as np
+import argparse
+import random
+from pathlib import Path
+from fourbynine import NInARowBestFirstSearch
+import csv
+
+# Input files for heuristic-quality evaluation live alongside this script, so the
+# script is portable across checkouts (no hardcoded /scratch path).
+HQ_INPUTS = Path(__file__).resolve().parent / "heuristic_quality_inputs"
+
+
+def search_from_position(position, heuristic, noise_enabled=True, seed=None):
+    """
+    Given a position and a heuristic, execute a search from the given position
+    and return the best move.
+    """
+    if seed:
+        heuristic.seed_generator(seed)
+    else:
+        heuristic.seed_generator(random.randint(0, 2**64))
+    heuristic.set_noise_enabled(noise_enabled)
+    bfs = NInARowBestFirstSearch(heuristic, position)
+    bfs.complete_search()
+    return bfs.get_tree()
+
+
+def bads_parameters_to_model_parameters(params):
+    """
+    Expands a truncated set of BADS parameters into a full set of heuristic params
+    for constructing a heuristic.
+
+    Args:
+        params: The BADS parameters to convert (of length 10)
+              [pruning, stopping_prob, feature_drop, lapse, c_opp, w_center, 2IAR_CON, 2IAR_DIS, 3IAR, 4IAR]
+
+    Returns:
+        The corresponding heuristic parameters (of length 58)
+    """
+    if (len(params) != 10):
+        raise Exception(
+            "Parameter file must contain 10 parameters: {}".format(params))
+    params = list(map(float, params))
+    out = [10000.0, params[0], params[1], params[3], 1, 1, params[5]]
+    # Feature weights: params[6:] = [2IAR_CON, 2IAR_DIS, 3IAR, 4IAR]
+    out.extend([x for x in params[6:]] * 4)
+    out.append(0)
+    out.extend([x * params[4] for x in params[6:]] * 4)
+    out.append(0)
+    out.extend([params[2]] * 17)
+    return out
+
+
+def get_heuristic_quality(params):
+    """
+    Given model parameters (of specifically length 58), evaluate the correlation of the
+    parameters with a pre-derived set of optimal parameters.
+
+    Returns:
+        A number in [-1, 1]: correlation of the given parameters with optimal parameters.
+    """
+    feature_counts = np.loadtxt(HQ_INPUTS / "optimal_feature_vals.txt")[:, -35:]
+    optimal_move_values = np.loadtxt(HQ_INPUTS / "opt_hvh.txt")[:, -36:]
+    # columns are player id, color, cross-validation group, number of pieces, chosen move, response time in ms
+    move_stats_hvh = np.loadtxt(HQ_INPUTS / "move_stats_hvh.txt", dtype=int)
+    num_pieces_hvh = move_stats_hvh[:, 3]
+
+    mask = ~np.isnan(optimal_move_values)
+    optimal_move_values[mask] = np.vectorize(
+        lambda x: -1 if x < -5000 else (1 if x > 5000 else 0))(optimal_move_values[mask])
+
+    player_color = move_stats_hvh[:, 1]
+    optimal_board_values = np.full_like(
+        player_color, fill_value=np.nan, dtype=float)
+    optimal_board_values[player_color == 0] = np.nanmax(
+        optimal_move_values[player_color == 0, :], axis=1)
+    optimal_board_values[player_color == 1] = - \
+        np.nanmin(optimal_move_values[player_color == 1, :], axis=1)
+
+    params = np.array(params)
+    f3inarow = (params[9]+params[28])/2
+    heuristic_values = np.tanh(0.4*np.sum((-2*player_color+1)[:, None]*feature_counts
+                                          * params[None, 6:41]/f3inarow, axis=1))
+    return np.corrcoef(heuristic_values, optimal_board_values)[0, 1]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse a parameters file and evaluate its heuristic quality "
+                    "(correlation with optimal parameters).")
+    parser.add_argument("-p", "--params", required=True, type=str,
+                        help="The file containing the parameters for the model.")
+    parser.add_argument("-o", "--output", required=False, type=str,
+                        help="Filename to write the statistic to as a CSV. Optional.")
+    args = parser.parse_args()
+    from parsers import parse_bads_parameter_file_to_model_parameters
+    params = parse_bads_parameter_file_to_model_parameters(args.params)
+    stats = get_heuristic_quality(params)
+    print(stats)
+    if args.output:
+        with open(args.output, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerow([stats])
+
+
+if __name__ == "__main__":
+    main()

--- a/model_fitting/parsers.py
+++ b/model_fitting/parsers.py
@@ -1,0 +1,258 @@
+from functools import total_ordering
+from fourbynine import fourbynine_board, fourbynine_pattern, fourbynine_move, Player_Player1, Player_Player2, bool_to_player, player_to_string
+from ninarow_utilities import bads_parameters_to_model_parameters
+import json
+import uuid
+
+
+@total_ordering
+class CSVMove:
+    """
+    Encodes a single move made by a player at a given position.
+    """
+    @staticmethod
+    def create(line):
+        """
+        Creates a CSVMove from a single CSV line. The format of the CSV string should be:
+
+        black_pieces white_pieces player move time [group_id] participant_id, where group_id is optional.
+
+        black_pieces and white_pieces should both be base-10 numbers encoding the positions of all of the black and white pieces on the board respectively as a bitfield, with the LSB corresponding to the upper left corner of the board, i.e. 0b1 corresponding to a piece at index 0.
+        player should be either the string Black, White, black, white, 0, or 1, where 0 corresponds to black and 1 corresponds to white.
+        move should be a base-10 number encoding the position at which the move being specified is played, i.e. 1 corresponding to a move at index 0, 2 to a move at index 1, 4 to index 2, etc.
+        time is the time in milliseconds that the player took to play the move.
+        group_id is an optional integer encoding a group ID for the player.
+        participant_id is a string denoting the given player.
+
+        Args:
+            line: The line to parse.
+
+        Returns: A CSVMove corresponding to the given line.
+        """
+        # Try splitting by comma
+        parameters = line.rstrip().split(',')
+        if (len(parameters) == 1):
+            # Otherwise, try spltting by space.
+            parameters = line.rstrip().split()
+        if (len(parameters) >= 6):
+            board = fourbynine_board(fourbynine_pattern(
+                int(parameters[0])), fourbynine_pattern(int(parameters[1])))
+
+            def parse_player(player):
+                if player.lower() == "white" or player == '1':
+                    return True
+                if player.lower() == "black" or player == '0':
+                    return False
+                raise Exception("Unrecognized player token: {}".format(player))
+
+            player = parse_player(parameters[2])
+            if (player != board.active_player()):
+                raise ValueError("Given player {} is not the active player on the given board: {}".format(
+                    player_to_string(player), board.to_string()))
+
+            def move_bitfield_to_index(move):
+                """
+                Takes a bitfield representing a move and converts it to its corresponding tile index.
+
+                Args:
+                    move: A move encoded as a one-hot bitfield with the single 1 corresponding to the moves position on the board.
+
+                Returns:
+                    The index of the move, where index 0 corresponds to the upper left of the board, incrementing in a row-major fashion.
+                """
+                if int(move).bit_count() != 1:
+                    raise Exception(
+                        "Invalid move given: {}. Moves are expected to be in bitfield format with a single bit set!".format(move))
+                return int(move).bit_length() - 1
+
+            move = fourbynine_move(move_bitfield_to_index(
+                parameters[3]), 0.0, board.active_player())
+            time = float(parameters[4])
+            if (len(parameters) == 6):
+                participant_id = parameters[5]
+                return CSVMove(board, move, time, 1, participant_id)
+            
+            elif (len(parameters) == 7):
+                group_id = int(parameters[5])
+                participant_id = parameters[6]
+                return CSVMove(board, move, time, group_id, participant_id)
+            
+            elif (len(parameters) == 8):
+                group_id = int(parameters[5])
+                participant_id = parameters[6]
+                unique_id = parameters[7]
+                return CSVMove(board, move, time, group_id, participant_id, unique_id)
+            else: 
+                raise Exception(
+                    "Given input has incorrect number of parameters (expected 6 - 8): " + line)
+        else:
+            raise Exception(
+                "Given input has incorrect number of parameters (expected at least 6): " + line)
+
+    def __init__(
+            self,
+            board,
+            move,
+            time,
+            group_id,
+            participant_id, 
+            unique_id = None):
+        """
+        Construct a move.
+
+        Args:
+            board: The board that the move was played on as a fourbynine_board object.
+            move: The move that was made as a fourbynine_move object.
+            time: The amount of time it took to play this move in milliseconds.
+            group_id: The integer group that this player belonged to.
+            participant_id: A string identifying the player.
+        """
+        self.board = board
+        self.move = move
+        # Test that the move is valid. This will throw if it isn't.
+        _ = self.board + self.move
+        self.player = board.active_player()
+        self.time = float(time)
+        self.group_id = int(group_id)
+        self.participant_id = str(participant_id)
+
+        if unique_id is not None: 
+            self.unique_id = unique_id
+        else: 
+            # automatically generates a unique string identifier for the move
+            self.unique_id = str(uuid.uuid4())
+
+    def __repr__(self):
+        """
+        Returns:
+            A valid CSV string representing the given move.
+        """
+        return "\t".join([str(int(self.board.get_pieces(Player_Player1).to_string(), 2)), str(int(self.board.get_pieces(Player_Player2).to_string(), 2)), player_to_string(self.player), str(2**self.move.board_position), str(self.time), str(self.group_id), self.participant_id, self.unique_id])
+
+    def __hash__(self):
+        """
+        Hashes the move.
+        """
+        return hash(str(self))
+
+    def __eq__(self, other):
+        """
+        Returns:
+            True if both moves are equivalent.
+        """
+        return str(self) == str(other)
+
+    def __lt__(self, other):
+        """
+        Returns:
+            True if a given move is "less than" another move. Ordering is mostly arbitrary, this function just establishes a canonical ordering.
+        """
+        return str(self) < str(other)
+
+    def __getstate__(self):
+        return str(self)
+
+    def __setstate__(self, state_string):
+        new_state = CSVMove.create(state_string)
+        self.__dict__ = new_state.__dict__
+
+
+def _parse_participant_csv(lines, group_id=1, ignore_csv_header = False):
+    """
+    Parses a list of CSV-encoded moves.
+
+    Args:
+        lines: A list of CSV strings encoding moves.
+        group_id: An optional group_id, used if the CSV line does not specify one.
+
+    Returns:
+        A list of CSVMove objects, one for each valid line passed in.
+    """
+    moves = []
+    # read all the lines and convert them into CSVMove objects
+    for i, line in enumerate(lines):
+        # Skip the first line if we're ignoring the CSV header.
+        if i == 0 and ignore_csv_header:
+            continue
+        # Skip empty lines
+        if not line.strip():
+            continue
+        else:
+            moves.append(CSVMove.create(line))
+    return moves
+
+
+def _parse_participant_json(json_file, group_id=1, participant_id="1"):
+    """
+    Parses a JSON string encoding games.
+
+    Args:
+        json_file: The file containing moves. The moves are expected to be at root["free_play"]["solution"] encoded as a string in the format "<first_move_index>-<second_move_index>-<third_move_index>-...".
+                   The color that the player was playing should be at root["free_play"]["player_color"], with the times each move took at root["free_play"]["all_move_RT"].
+        group_id: The group ID to assign to all games in this file.
+        participant_id: The name of the participant for all games in this file.
+
+    Returns:
+        A list of CSVMove objects, one for each move encoded in the JSON file.
+    """
+    root = json.loads(json_file)
+    moves = []
+    for game in root["free_play"]:
+        if not game:
+            continue
+        board = fourbynine_board()
+        solution = game["solution"].split("-")
+        input_player = game["player_color"].lower() == "white"
+        times = game["all_move_RT"]
+        player = False  # Corresponds to Black
+        game_valid = True
+        candidate_moves = []
+        for p in solution:
+            move = fourbynine_move(int(p), 0.0, bool_to_player(player))
+            try:
+                if player == input_player:
+                    candidate_moves.append(
+                        CSVMove(board, move, times[len(candidate_moves)], group_id, participant_id))
+                board += move
+            except Exception as exce:
+                print("Skipping solution {} as it is malformed.".format(solution))
+                game_valid = False
+                break
+            player = not player
+        if game_valid:
+            moves.extend(candidate_moves)
+    return moves
+
+
+def parse_participant_file(f, group_id=1, participant_id="1", ignore_csv_header=False):
+    """
+    Parses a file by first attempting to parse it as a JSON file, and then falling back to a CSV file.
+
+    Args:
+        f: The path to the file to parse.
+        group_id: The group ID to assign to all games in this file. If the file is a CSV file, ignored if the CSV contains group information.
+        participant_id: The name of the participant for all games in this file. Ignored if the file is a CSV file.
+        ignore_csv_header: If True, the first line of the CSV file will be ignored.
+    """
+    with open(f, 'r') as lines:
+        try:
+            return _parse_participant_json(lines.read(), group_id, participant_id)
+        except json.JSONDecodeError:
+            print(
+                "File is either not a JSON file, or is malformed. Attempting to parse as a CSV...")
+            lines.seek(0)
+        return _parse_participant_csv(lines, group_id, ignore_csv_header)
+
+
+def parse_bads_parameter_file_to_model_parameters(f):
+    """
+    Parses a file containing a list of comma-separated parameters for a model into a Python list.
+
+    Args:
+        f: The path to the file to parse.
+    """
+    with open(f, 'r') as lines:
+        for line in lines:
+            if line.startswith("#"):
+                continue
+            return bads_parameters_to_model_parameters(line.split(","))


### PR DESCRIPTION
Re-introduces the tree-statistics tooling (removed in the recent refactor) and makes it construct the heuristic the **same way the fitter does**, so planning-depth / branching-factor numbers reflect the exact model that was fit.

## Changes
- **`calculate_tree_statistics.py`** (re-added, fixed): builds the heuristic via `tree_search.TreeSearch.set_params(...)` — the modular `create(7, False) + add_feature_group` path used by `fit_one_start` — instead of the legacy `bads_parameters_to_model_parameters → create(58, True)` path. Reads the fitted BADS parameters directly in model order (what the fit/adapter writes).
- **`parsers.py`, `ninarow_utilities.py`** (re-added): dependencies of the stats tooling (`parse_participant_file`, `search_from_position`, `get_heuristic_quality`). `ninarow_utilities` uses `__file__`-relative paths for its heuristic-quality input files.

## Why
The fit and the old stats built the C++ heuristic through two different APIs. The control params (incl. `stopping_prob`) matched, so **planning depth is ~unchanged** (it's `stopping_prob`-dominated), but the feature-weight wiring differed — so node-count/branching-shape could diverge, and the construction could silently drift from the fitter. This pins them together.

## Follow-up (not in this PR)
- `get_heuristic_quality` still computes heuristic values via a legacy hardcoded 58-param numpy formula (`params[6:41]`) that assumes the old feature layout; it should be re-derived against the new template/feature structure before being trusted with the new models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)